### PR TITLE
wait until timeout before analyse()

### DIFF
--- a/src/mutex.rs
+++ b/src/mutex.rs
@@ -69,6 +69,7 @@ impl<T: ?Sized> Mutex<T> {
         loop {
             let mut guard = self.manager.write_lock();
             let representation = guard.locks.get_mut(&self.key).unwrap();
+
             if representation.try_write_lock() {
                 let returned_guard = MutexGuard {
                     inner: unsafe { &mut *(self as *const _ as *mut _) },
@@ -81,8 +82,9 @@ impl<T: ?Sized> Mutex<T> {
             } else if Instant::now().duration_since(start) > timeout {
                 representation.subscribe_write();
                 guard.analyse();
-                std::thread::yield_now();
             }
+
+            std::thread::yield_now();
         }
     }
 }

--- a/src/rwlock.rs
+++ b/src/rwlock.rs
@@ -81,6 +81,7 @@ impl<T: ?Sized> RwLock<T> {
         loop {
             let mut guard = self.manager.write_lock();
             let representation = guard.locks.get_mut(&self.key).unwrap();
+
             if representation.try_read_lock() {
                 let returned_guard = RwLockReadGuard {
                     inner: &self,
@@ -93,8 +94,9 @@ impl<T: ?Sized> RwLock<T> {
             } else if Instant::now().duration_since(start) > timeout {
                 representation.subscribe_read();
                 guard.analyse();
-                std::thread::yield_now();
             }
+
+            std::thread::yield_now();
         }
     }
 
@@ -105,6 +107,7 @@ impl<T: ?Sized> RwLock<T> {
         loop {
             let mut guard = self.manager.write_lock();
             let representation = guard.locks.get_mut(&self.key).unwrap();
+
             if representation.try_write_lock() {
                 let returned_guard = RwLockWriteGuard {
                     inner: unsafe { &mut *(self as *const _ as *mut _) },
@@ -117,8 +120,9 @@ impl<T: ?Sized> RwLock<T> {
             } else if Instant::now().duration_since(start) > timeout {
                 representation.subscribe_write();
                 guard.analyse();
-                std::thread::yield_now();
             }
+
+            std::thread::yield_now();
         }
     }
 }


### PR DESCRIPTION
Implements a timeout mentioned in #6 .
It is currently hardcoded to one second. I'm not sure how the configuration (if it is indeed really needed) should be done. For now this is sufficient to me, it gives a good noticeable performance boost.